### PR TITLE
Remove restriction on specifying size in MB.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,8 +18,6 @@ Depends on:
 
 See example directory
 
-NB: define LV sizes in Megabytes.
-
 ## Supported Platforms ##
 
 Tested on Red Hat EL5/EL6/EL7'ish with filesystems ext2, ext3, ext4 & xfs.

--- a/manifests/lvconfig.pp
+++ b/manifests/lvconfig.pp
@@ -4,8 +4,8 @@ define lvmconfig::lvconfig ( $vg, $fs, $mnt_point, $size, $mnt_opts ) {
   # Readability
   $lv = $name
 
-  # Do nothing if size is not defined in Megabytes
-  if $size =~ /^\d+M$/ {
+  # Make sure the size argument is valid for lvcreate
+  if $size =~ /^\d+[bBsSkKmMgGtTpPeE]?$/ {
     logical_volume { $lv :
       ensure       => present,
       volume_group => $vg,
@@ -38,7 +38,7 @@ define lvmconfig::lvconfig ( $vg, $fs, $mnt_point, $size, $mnt_opts ) {
       creates => $mnt_point,
     }
   } else {
-    fail("Define size in megabytes, eg: 1024M (LV ${lv} has ${size})")
+    fail("Define size in megabytes, eg: 1024 or specify a valid suffix [BSKMGTPE] - (LV ${lv} has ${size})")
   }
 
 }

--- a/manifests/lvconfig.pp
+++ b/manifests/lvconfig.pp
@@ -4,7 +4,7 @@ define lvmconfig::lvconfig ( $vg, $fs, $mnt_point, $size, $mnt_opts ) {
   # Readability
   $lv = $name
 
-  # Make sure the size argument is valid for lvcreate
+  # Make sure the size argument is valid for the logical_volume type
   if $size =~ /^[0-9]+(\.[0-9]+)?[KMGTPE]/i {
     logical_volume { $lv :
       ensure       => present,
@@ -38,7 +38,7 @@ define lvmconfig::lvconfig ( $vg, $fs, $mnt_point, $size, $mnt_opts ) {
       creates => $mnt_point,
     }
   } else {
-    fail("Define size in megabytes, eg: 1024 or specify a valid suffix [BSKMGTPE] - (LV ${lv} has ${size})")
+    fail("Define size with a valid suffix [KMGTPE] - (LV ${lv} has ${size})")
   }
 
 }

--- a/manifests/lvconfig.pp
+++ b/manifests/lvconfig.pp
@@ -5,7 +5,7 @@ define lvmconfig::lvconfig ( $vg, $fs, $mnt_point, $size, $mnt_opts ) {
   $lv = $name
 
   # Make sure the size argument is valid for lvcreate
-  if $size =~ /^\d+[bBsSkKmMgGtTpPeE]?$/ {
+  if $size =~ /^[0-9]+(\.[0-9]+)?[KMGTPE]/i {
     logical_volume { $lv :
       ensure       => present,
       volume_group => $vg,

--- a/manifests/lvconfig.pp
+++ b/manifests/lvconfig.pp
@@ -5,7 +5,7 @@ define lvmconfig::lvconfig ( $vg, $fs, $mnt_point, $size, $mnt_opts ) {
   $lv = $name
 
   # Make sure the size argument is valid for the logical_volume type
-  if $size =~ /^[0-9]+(\.[0-9]+)?[KMGTPE]/i {
+  if $size =~ /^[0-9]+(\.[0-9]+)?[KMGTPEkmgtpe]/ {
     logical_volume { $lv :
       ensure       => present,
       volume_group => $vg,


### PR DESCRIPTION
Not sure if there was a reason you forced file sizes in MB, but from looking at the code it doesn't appear that there's any reason not to allow all valid suffixes. I started with the acceptable values from the lvcreate man page, however realized that the puppetlabs-lvm module had tighter restrictions so I went with their (slightly modified) regex to validate $size.